### PR TITLE
Document an optional single-component source installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ import { AtTheHorizon } from "@designcodeio/threeui/components/AtTheHorizon";
 
 Components that render full HTML documents expect their runtime files at the same root-relative URLs used by the ThreeUI preview. Copy the needed files from `node_modules/@designcodeio/threeui/lib-dist/assets/` into your app's public directory, or override the component's `sourceUrl` or `assetBaseUrl` prop where available.
 
+## Copy Community source
+
+If you want one free Community component as editable source instead of an npm dependency, the independent [ThreeUI CLI](https://github.com/sjh9714/threeui-cli) copies the component together with its shared files and public assets:
+
+```bash
+npx threeui-cli add kage-landing-page
+```
+
+It reads the published `public/source-code.json` registry, keeps the original paths, verifies every SHA-256 digest, and refuses to replace changed files unless `--force` is supplied.
+
 ## Pro source access
 
 Pro implementation source is deliberately not published to npm. Active ThreeUI Pro members authenticate through the browser and download an entitled source bundle with the public CLI:


### PR DESCRIPTION
This adds an optional source ownership path for people who want one Community component in their own source tree.

ThreeUI now has an official React package. This tool serves a different case. It copies the selected component together with the shared files and public assets required by full HTML components, then keeps their original paths intact.

The official `@designcodeio/threeui-cli` handles entitled Pro source. This PR only documents the login-free Community source path.

![Install the Kage landing page with ThreeUI CLI](https://raw.githubusercontent.com/sjh9714/threeui-cli/main/docs/assets/demo.gif)

The CLI reads the published source registry, verifies every SHA-256 digest and refuses to replace different local files. It is labeled as an independent community tool in its README.

I tested npm version 0.2.1 from a fresh temporary directory with Kage Landing Page, Spark Badge and Predictive Arc. The Kage run copied its HTML, WebGL assets and editable React source, then rendered locally.
