### PR TITLE
Verify automated Community sync pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - automation/community-sync
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub suppresses `pull_request` workflows for pull requests created by `github-actions[bot]`. Run the same full package verification directly when the `automation/community-sync` branch is pushed, so automated sync PRs receive build and anonymous-install proof without a manual Actions approval.

Observed on sync PR #6 / Actions run `32573679771`.