### PR TITLE
docs: fix grammar issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The sync fails closed, filters Pro and Beta before generating the public import 
 - `public/source-code.json` — Community source bundles used by the Code tab
 - `src/data/shaders.tsx` — Community-only catalog and renderer imports
 
-The private ThreeUI repository runs this synchronization after every successful push to `main`. A no-op sync exits without a release. Changes update the `automation/community-sync` branch and open one reviewed pull request here. New public components, variants, or controls infer a minor release; removals infer a major release; compatible source changes infer a patch release. Merging a versioned sync pull request publishes the new package through npm trusted publishing with provenance.
+The private ThreeUI repository runs this synchronization after every successful push to `main`. A no-op sync exits without a release. Changes update the `automation/community-sync` branch and open one reviewed pull request here. New public components, variants, or controls trigger a minor release; removals trigger a major release; compatible source changes trigger a patch release. Merging a versioned sync pull request publishes the new package through npm trusted publishing with provenance.
 
 The public workflow also runs a clean build, boundary audit, package creation, and anonymous installation smoke test before release. The Pro installer is versioned and published separately; changes to Pro component content do not require a CLI release.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 84).

## Problem

"Infer" means to deduce or conclude from evidence; only a reasoning agent can infer. The inanimate subjects (components, variants, controls, removals, changes) cannot infer anything. The intended meaning is that these changes trigger or necessitate a release.

The problematic text:

```markdown
infer a minor release; removals infer a major release; compatible source changes infer a patch release
```

## Fix

Replaced with:

```markdown
trigger a minor release; removals trigger a major release; compatible source changes trigger a patch release
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change
