### PR TITLE
docs: add a one-click deploy option next to Run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ npm install
 npm run dev
 ```
 
+Or deploy it hosted, without cloning anything:
+
+[![Deploy on InstaPods](https://instapods.com/deploy-button.svg)](https://app.instapods.com/dashboard/pods/create?repo=https://github.com/MengTo/threeui&ref=gh-threeui)
+
 Run the complete publication boundary, type, and production-build checks:
 
 ```bash


### PR DESCRIPTION
I deployed this repo as it is to see whether the catalog runs without any setup, and it builds and serves fine: https://lt-threeui.nbg1-3.instapods.app

The link I added does the same thing for a reader: clone, build, serve over HTTPS. I put it in Run locally because that is where someone decides how they want to try it.

Disclosure: I work on InstaPods, which the link points at. No hard feelings if you close this.